### PR TITLE
fix: remove useless curly bracket

### DIFF
--- a/utils/observable.ts
+++ b/utils/observable.ts
@@ -24,7 +24,7 @@ const toValidUsernameObservable = (
         new Observable<string>((observer) => {
           const source = axios.CancelToken.source();
           axios
-            .get<ApiAnswer>(`/api/users/${username}}`, {
+            .get<ApiAnswer>(`/api/users/${username}`, {
               cancelToken: source.token,
             })
             .then(({ data: { error: e } }) => {


### PR DESCRIPTION
there request url has an extra right curly bracket, which will pass the wrong userid to the API